### PR TITLE
Update utils.py

### DIFF
--- a/mudi/utils.py
+++ b/mudi/utils.py
@@ -44,7 +44,7 @@ def aggr_markers(adata, uns='rank_genes_groups', params=['names','scores','pvals
     Assumes 'rank_genes_groups' has already been called to find group markers
     in AnnData Object.
     """
-    assert adata.uns['rank_genes_groups'], 'Compute differentially expressed genes first.'
+    assert adata.uns[uns], 'Compute differentially expressed genes first.'
 
     joint = pd.concat(
         [pd.DataFrame(pd.DataFrame(adata.uns[uns][param]).T.stack()).reset_index().rename(columns={'level_0':'cluster','level_1':'no.',0:param})


### PR DESCRIPTION
Fixed `assert` command under `aggr_markers()` to account for situations where `'rank_genes_groups'` is not used as the `.uns` name.