### PR TITLE
Adding make_sparse flag to recipe

### DIFF
--- a/mudi/process.py
+++ b/mudi/process.py
@@ -116,7 +116,7 @@ def recipe(
     bbknn: Union[None, str] = None,
     issparse: bool = False,
     verbose: bool = False,
-    make_sparse: bool = False,
+    make_sparse: bool = True,
     **kwargs
     ) -> AnnData:
     """


### PR DESCRIPTION
Added the optional flag make_sparse. The flag determines if the function recipe does a sparse conversion of adata.X before returning the AnnData object adata.